### PR TITLE
Add collision events

### DIFF
--- a/chicken-hen-web/README.md
+++ b/chicken-hen-web/README.md
@@ -91,6 +91,7 @@ This script will:
 - **Platform Types**: Normal, Moving, and Fading platforms
 - **Boss Fight**: Defeat the boss after rescuing Zeldina
 - **Real-time Synchronization**: All player movements and actions are synchronized
+- **Collision Events**: Detect when a player crushes an enemy or takes damage
 
 ## Game Controls
 

--- a/chicken-hen-web/client/game.js
+++ b/chicken-hen-web/client/game.js
@@ -522,11 +522,22 @@ function handleMessage(message) {
             
         case 'enemyKilled':
             // Remove enemy
-            enemies = enemies.filter(e => 
+            enemies = enemies.filter(e =>
                 !(e.pos.x === message.data.x && e.pos.y === message.data.y)
             );
             break;
-            
+
+        case 'enemyCrushed':
+            console.log('Enemy crushed:', message.enemy);
+            break;
+
+        case 'playerDamaged':
+            if (message.health !== undefined && players[myId]) {
+                players[myId].health = message.health;
+                players[myId].invulnerable = 120; // Match server invulnerability
+            }
+            break;
+
         case 'zeldinaRescued':
             if (zeldina) zeldina.rescued = true;
             break;


### PR DESCRIPTION
## Summary
- detect when enemies are crushed or damage players
- update the web client to react to `enemyCrushed` and `playerDamaged` events
- document collision events in README

## Testing
- `node --check chicken-hen-web/server/websocket-handler.js`
- `node --check chicken-hen-web/client/game.js`


------
https://chatgpt.com/codex/tasks/task_e_6873b002dc20832e94da89a2ce12ca7a